### PR TITLE
Add leveling to z/e-only moves

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -11235,11 +11235,6 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
    * Returns true if the caller didn't update current_position.
    */
   inline bool prepare_move_to_destination_cartesian() {
-    // Do not use feedrate_percentage for E or Z only moves
-    if (current_position[X_AXIS] == destination[X_AXIS] && current_position[Y_AXIS] == destination[Y_AXIS]) {
-      line_to_destination();
-    }
-    else {
       #if ENABLED(MESH_BED_LEVELING)
         if (mbl.active()) {
           mesh_line_to_destination(MMS_SCALED(feedrate_mm_s));
@@ -11260,7 +11255,7 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
         else
       #endif
           line_to_destination(MMS_SCALED(feedrate_mm_s));
-    }
+
     return false;
   }
 


### PR DESCRIPTION
This fixes #6618. Longer explanation in that issue but essentially z and e only moves shouldn't bypass the leveling functions because this results in movements to wrong positions (z-only moves) or movements that shouldn't be there (e-only moves). 

A simple example is if you move down the z-axis to the bed: If you have some kind of leveling you would expect the nozzle to stop at the corrected position and not the uncorrected position.